### PR TITLE
caddy: add download folder

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -5,6 +5,7 @@
         not path /course-plus-data*
         not path /libsjtu*
         not path /monitor*
+        not path /download/*
     }
     @monitor {
         path /monitor*


### PR DESCRIPTION
`download` folder will be used to store binaries (maybe Android apps that will be published in the future)